### PR TITLE
feat: Use cache dir from Terraform config file if present

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"log"
 	"os"
-	"path/filepath"
+	"io/ioutil"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/hashicorp/hcl"
 )
 
 var (
@@ -29,13 +30,46 @@ func Execute() {
 	rootCmd.Execute()
 }
 
+func getCacheDirFromTFConfig() (string, error) {
+	tfCfgPath, ok := os.LookupEnv("TF_CLI_CONFIG_FILE")
+	if !ok {
+		// The file not existing is not an error
+		return "", nil
+	}
+
+	data, err := ioutil.ReadFile(tfCfgPath)
+	if err != nil {
+		return "", err
+	}
+
+	var cfg struct{
+		PluginCacheDir string `hcl:"plugin_cache_dir"`
+	}
+	err = hcl.Unmarshal(data, &cfg)
+	if err != nil {
+		return "", err
+	}
+
+	return cfg.PluginCacheDir, nil
+}
+
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	cacheDir := "$HOME/.terraform.d/plugin-cache"
+	configuredCacheDir, err := getCacheDirFromTFConfig()
+	if err != nil {
+		log.Println("Could not read plugin cache directory from tfrc file, ignoring", err)
+	}
+	if configuredCacheDir != "" {
+		cacheDir = configuredCacheDir
+	}
+	cacheDir = os.ExpandEnv(cacheDir)
 
 	// Global Flags
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file for tpm")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug mode")
-	rootCmd.PersistentFlags().StringP("terraform-plugin-cache-dir", "p", filepath.Join(os.ExpandEnv("$HOME"), "/.terraform.d/plugin-cache"), "the location of the Terraform plugin cache directory")
+	rootCmd.PersistentFlags().StringP("terraform-plugin-cache-dir", "p", cacheDir, "the location of the Terraform plugin cache directory")
 	rootCmd.PersistentFlags().StringP("terraform-registry", "r", "registry.terraform.io", "the Terraform registry provider hostname")
 	rootCmd.PersistentFlags().VisitAll(bindCustomFlag)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -64,7 +65,7 @@ func init() {
 	if configuredCacheDir != "" {
 		cacheDir = configuredCacheDir
 	}
-	cacheDir = os.ExpandEnv(cacheDir)
+	cacheDir = filepath.Clean(os.ExpandEnv(cacheDir))
 
 	// Global Flags
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file for tpm")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.15.0
 	github.com/charmbracelet/bubbletea v0.24.0
 	github.com/charmbracelet/lipgloss v0.7.1
+	github.com/hashicorp/hcl v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -20,7 +21,6 @@ require (
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect


### PR DESCRIPTION
This PR makes `tpm` read the location of the plugin cache directory from Terraform's configuration file, if `TF_CLI_CONFIG_FILE` is set and readable.
